### PR TITLE
IA-2150 cloudfront

### DIFF
--- a/terraform/fargate.tf
+++ b/terraform/fargate.tf
@@ -8,12 +8,12 @@ locals {
     HUBZONE_MAP_DB_HOST = local.postgres_fqdn
 
     # These services live behind CloudFront, so the base domain will be identical upon deployment
-    HUBZONE_MAP_HOST     = "https://${local.env.service_name}.${local.env.fqdn_base}"
-    HUBZONE_REPORT_HOST  = "https://hubzone-report.${local.env.fqdn_base}"
-    HUBZONE_WMS_URL_ROOT = "https://hubzone-geoserver.${local.env.fqdn_base}/geoserver/gwc/service/wms?"
-    #HUBZONE_MAP_HOST     = "https://${local.public_fqdn}"
-    #HUBZONE_REPORT_HOST  = "https://${local.public_fqdn}"
-    #HUBZONE_WMS_URL_ROOT = "https://${local.public_fqdn}/geoserver/gwc/service/wms?"
+    #HUBZONE_MAP_HOST     = "https://${local.env.service_name}.${local.env.fqdn_base}"
+    #HUBZONE_REPORT_HOST  = "https://hubzone-report.${local.env.fqdn_base}"
+    #HUBZONE_WMS_URL_ROOT = "https://hubzone-geoserver.${local.env.fqdn_base}/geoserver/gwc/service/wms?"
+    HUBZONE_MAP_HOST     = "https://${local.public_fqdn}"
+    HUBZONE_REPORT_HOST  = "https://${local.public_fqdn}"
+    HUBZONE_WMS_URL_ROOT = "https://${local.public_fqdn}/geoserver/gwc/service/wms?"
 
     # Users do not connect directly to hubzone-api; use the API url directly
     HUBZONE_API_HOST = "https://hubzone-api.${local.env.fqdn_base}" #TODO: API has not been deployed yet.

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -25,7 +25,6 @@ locals {
     demo = {
       fqdn_base        = "demo.sba-one.net"
       cert_domain      = "sba-one.net"
-      public_subdomain = "hubzone"
     }
     stg = {
       fqdn_base = "stg.certify.sba.gov"


### PR DESCRIPTION
- Working fargate infrastructure
- Removed aws cli; cleaned up entrypoint
- Added tf files to git ignore
- Updated Gems
- Added style ignore to rubocop
- rubocop auto correct was run
- Updated circleci config for build and deploy
- Added top lvl comment for rubocop
- Fixed ecr repository in build-containers
- Added terraform to dockerignore
- Fixed terraform dir in docker ignore
- Updated postgres to version 12
- revert postgres change due to aurora version
- Fixed entrypoint svc name to match fargate svc name
- Fixed backend
- IA-1973: Update postgres version in docker-compose, circle
- Fixed vars and removed comments from fargate
- IA-2013: Fix postgis containers
- IA-2013: Fix postgresql-client name
- Moved env variables to docker-compose
- Changed api_key for testing
- Testing variables
- Removed .env files
- Added dougs test key
- Modified key var
- Replaced key working test
- IA-2159: Swapping service domains to be consistent with the architecture diagam
- IA-2150: adjust endpoints for cloudfront
