### PR TITLE
hide QDA Disaster Publish field from side panel

### DIFF
--- a/app/views/governorsmap/additional_details/_qct_qda.html.erb
+++ b/app/views/governorsmap/additional_details/_qct_qda.html.erb
@@ -10,10 +10,12 @@
   <h6><%= t('hubzone_assertions.additional_details.disaster_designation') %></h6>
   <h5><%= qualification["qda_designation"].blank? ? '--' : date_to_string(qualification["qda_designation"]) %></h5>
 </div>
+<!-- 
 <div class="designation-details-item">
   <h6><%= t('hubzone_assertions.additional_details.disaster_publish') %></h6>
   <h5><%= qualification["qda_publish"].blank? ? '--' : date_to_string(qualification["qda_publish"]) %></h5>
 </div>
+-->
 <div class="designation-details-item">
   <h6><%= t('hubzone_assertions.additional_details.tract_id') %></h6>
   <h5><%= qualification["tract_fips"].blank? ? '--' : qualification["tract_fips"] %></h5>

--- a/app/views/governorsmap/additional_details/_qnmc_qda.html.erb
+++ b/app/views/governorsmap/additional_details/_qnmc_qda.html.erb
@@ -10,10 +10,12 @@
   <h6><%= t('hubzone_assertions.additional_details.disaster_designation') %></h6>
   <h5><%= qualification["qda_designation"].blank? ? '--' : date_to_string(qualification["qda_designation"]) %></h5>
 </div>
+<!--
 <div class="designation-details-item">
   <h6><%= t('hubzone_assertions.additional_details.disaster_publish') %></h6>
   <h5><%= qualification["qda_publish"].blank? ? '--' : date_to_string(qualification["qda_publish"]) %></b></h5>
 </div>
+-->
 <div class="designation-details-item">
   <h6><%= t('hubzone_assertions.additional_details.county_id') %></h6>
   <h5><%= qualification["county_fips"].blank? ? '--' : qualification["county_fips"] %></h5>

--- a/app/views/map/additional_details/_qct_qda.html.erb
+++ b/app/views/map/additional_details/_qct_qda.html.erb
@@ -10,10 +10,12 @@
   <h6><%= t('hubzone_assertions.additional_details.disaster_designation') %></h6>
   <h5><%= qualification["qda_designation"].blank? ? '--' : date_to_string(qualification["qda_designation"]) %></h5>
 </div>
+<!--
 <div class="designation-details-item">
   <h6><%= t('hubzone_assertions.additional_details.disaster_publish') %></h6>
   <h5><%= qualification["qda_publish"].blank? ? '--' : date_to_string(qualification["qda_publish"]) %></h5>
 </div>
+-->
 <div class="designation-details-item">
   <h6><%= t('hubzone_assertions.additional_details.tract_id') %></h6>
   <h5><%= qualification["tract_fips"].blank? ? '--' : qualification["tract_fips"] %></h5>

--- a/app/views/map/additional_details/_qnmc_qda.html.erb
+++ b/app/views/map/additional_details/_qnmc_qda.html.erb
@@ -2,10 +2,12 @@
   <h6><%= t('hubzone_assertions.additional_details.disaster_name') %></h6>
   <h5><%= qualification["incident_description"].blank? ? '--' : qualification["incident_description"] %></h5>
 </div>
+<!--
 <div class="designation-details-item">
   <h6><%= t('hubzone_assertions.additional_details.disaster_declaration') %></h6>
   <h5><%= qualification["qda_declaration"].blank? ? '--' : date_to_string(qualification["qda_declaration"]) %></h5>
 </div>
+-->
 <div class="designation-details-item">
   <h6><%= t('hubzone_assertions.additional_details.disaster_designation') %></h6>
   <h5><%= qualification["qda_designation"].blank? ? '--' : date_to_string(qualification["qda_designation"]) %></h5>


### PR DESCRIPTION
In HUBZone Map Side panel "Disaster Publish" field got hide.
![image](https://github.com/USSBA/hubzone-webmap/assets/108353205/3251482c-55d7-4b0e-9b4f-a971e94f59dd)
