### PR TITLE
Adding httpOnly in cookie

### DIFF
--- a/terraform/cloudfront.tf
+++ b/terraform/cloudfront.tf
@@ -242,6 +242,10 @@ resource "aws_cloudfront_distribution" "distribution" {
       name  = "x-ussba-origin-token"
       value = nonsensitive(data.aws_ssm_parameter.origin_token.value)
     }
+    custom_header {
+      name  = "Set-Cookie"
+      value = "HttpOnly"
+    }
 
     custom_origin_config {
       http_port                = 80


### PR DESCRIPTION
Setting cloudfront header to add HttpOnly to cookie to satisfy vulnerability fix.